### PR TITLE
Add tooltips to icons without a description

### DIFF
--- a/Mythic/Localizable.xcstrings
+++ b/Mythic/Localizable.xcstrings
@@ -2990,6 +2990,9 @@
         }
       }
     },
+    "Delete the Game" : {
+
+    },
     "Dismiss loading" : {
       "localizations" : {
         "ar" : {
@@ -3557,6 +3560,9 @@
           }
         }
       }
+    },
+    "Download the Game" : {
+
     },
     "Downloaded %lf MiB, Written %lf" : {
       "extractionState" : "stale",
@@ -9283,6 +9289,9 @@
         }
       }
     },
+    "Refresh the Library" : {
+
+    },
     "Restart Onboarding…" : {
       "localizations" : {
         "ar" : {
@@ -10421,6 +10430,9 @@
           }
         }
       }
+    },
+    "Start the Game" : {
+
     },
     "Stop" : {
       "localizations" : {
@@ -12699,6 +12711,12 @@
           }
         }
       }
+    },
+    "You need to update the Game" : {
+
+    },
+    "You need to verify this Game before playing" : {
+
     }
   },
   "version" : "1.0"

--- a/Mythic/Views/GameList/GameList.swift
+++ b/Mythic/Views/GameList/GameList.swift
@@ -233,6 +233,7 @@ struct GameListView: View {
                                             }
                                             .buttonStyle(.plain)
                                             .controlSize(.large)
+                                            .help("Settings")
                                             
                                             // MARK: Update Button
                                             if Legendary.needsUpdate(game: game) {
@@ -254,6 +255,7 @@ struct GameListView: View {
                                                 }
                                                 .buttonStyle(.plain)
                                                 .controlSize(.large)
+                                                .help("You need to update the Game")
                                             }
                                             
                                             if game.isLegendary,
@@ -283,6 +285,7 @@ struct GameListView: View {
                                                 })
                                                 .buttonStyle(.plain)
                                                 .controlSize(.large)
+                                                .help("You need to verify this Game before playing")
                                             } else {
                                                 // MARK: Play Button
                                                 Button {
@@ -314,6 +317,7 @@ struct GameListView: View {
                                                 }
                                                 .buttonStyle(.plain)
                                                 .controlSize(.large)
+                                                .help("Start the Game")
                                             }
                                             
                                             // MARK: Delete button
@@ -335,6 +339,7 @@ struct GameListView: View {
                                             }
                                             .buttonStyle(.plain)
                                             .controlSize(.large)
+                                            .help("Delete the Game")
                                         } else {
                                             ProgressView()
                                                 .controlSize(.small)
@@ -384,6 +389,7 @@ struct GameListView: View {
                                             .shadow(color: .gray, radius: 10, x: 1, y: 1)
                                             .buttonStyle(.plain)
                                             .controlSize(.large)
+                                            .help("Download the Game")
                                         }
                                     }
                                 }

--- a/Mythic/Views/Navigation/Library/Library.swift
+++ b/Mythic/Views/Navigation/Library/Library.swift
@@ -40,6 +40,7 @@ struct LibraryView: View {
                     } label: {
                         Image(systemName: "plus.app")
                     }
+                    .help("Import a Game")
                 }
                 
                 // MARK: Refresh Button
@@ -49,6 +50,7 @@ struct LibraryView: View {
                     } label: {
                         Image(systemName: "arrow.clockwise")
                     }
+                    .help("Refresh the Library")
                 }
             }
         


### PR DESCRIPTION
Add tooltips to icons without a description.
Some Screenshots:

![IMG_0310](https://github.com/MythicApp/Mythic/assets/69924019/e653d955-cc8e-4e5d-8fe8-5d2bf0aceff4)
![IMG_0309](https://github.com/MythicApp/Mythic/assets/69924019/7b2d2d18-3672-4673-bc5c-c47de9518699)
![IMG_0308](https://github.com/MythicApp/Mythic/assets/69924019/216b1303-529c-466f-b9ab-1f9643db19b8)
