### PR TITLE
Update `SupportView` to dynamically set Discord widget theme

### DIFF
--- a/Mythic/Views/Navigation/Support.swift
+++ b/Mythic/Views/Navigation/Support.swift
@@ -18,10 +18,20 @@ import Shimmer
 import SwordRPC
 
 struct SupportView: View {
+    @Environment(\.colorScheme) var colorScheme
+    
+    private var colorSchemeValue: String {
+        colorScheme == .dark ? "dark" : "light"
+    }
+    
     var body: some View {
         HStack {
             VStack {
-                WebView(url: .init(string: "https://discord.com/widget?id=1154998702650425397&theme=dark")!, error: .constant(nil), isLoading: .constant(nil))
+                WebView(
+                    url: .init(string: "https://discord.com/widget?id=1154998702650425397&theme=\(colorSchemeValue)")!,
+                    error: .constant(nil),
+                    isLoading: .constant(nil)
+                )
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(.background)


### PR DESCRIPTION
This adds dynamic color scheme support to the discord web widget based on the macOS system settings. 

https://github.com/MythicApp/Mythic/assets/47460844/248a4dde-6a65-4fd3-a222-3db95a5b6a48

