### PR TITLE
Fix game favorites thumbnail always showing blurred

### DIFF
--- a/Mythic/Views/Unified/Models/CompactGameCard.swift
+++ b/Mythic/Views/Unified/Models/CompactGameCard.swift
@@ -56,7 +56,7 @@ struct CompactGameCard: View {
                             .resizable()
                             .aspectRatio(1, contentMode: .fill)
                             .clipShape(.rect(cornerRadius: 20))
-                            .blur(radius: 20.0)
+                            .modifier(FadeInModifier())
                     case .failure:
                         // fallthrough
                         RoundedRectangle(cornerRadius: 20)


### PR DESCRIPTION
The image was always blurred. This fixes that showing the game image as one would expect.

## before
![image](https://github.com/MythicApp/Mythic/assets/47460844/f4fb7ab9-b416-4e18-81a0-abe89a04dbaf)

## after 
![image](https://github.com/MythicApp/Mythic/assets/47460844/0306842f-db01-4e45-924d-3b8be8094147)
![CleanShot 2024-06-21 at 21 44 32](https://github.com/MythicApp/Mythic/assets/47460844/6005858a-9244-4047-a004-83af4a5bbc5f)
