### PR TITLE
chore: update to new URL

### DIFF
--- a/Mythic/Info.plist
+++ b/Mythic/Info.plist
@@ -12,7 +12,7 @@
 		</dict>
 	</array>
 	<key>SUFeedURL</key>
-	<string>https://getmythic.app/appcast.xml</string>
+	<string>https://dl.getmythic.app/updates/update.xml</string>
 	<key>SUPublicEDKey</key>
 	<string>g+sJ+Hhxtb5ziscjMaoIvjMcvycB1PpZhhRJeoF+YSM=</string>
 </dict>


### PR DESCRIPTION
This pull request makes a small configuration change to the update feed URL in the `Mythic/Info.plist` file. The new URL points to a different server for app updates.

* Changed the value of `SUFeedURL` from `https://getmythic.app/appcast.xml` to `https://dl.getmythic.app/updates/update.xml` in `Mythic/Info.plist`.