### PR TITLE
fix: remove unused ZIPFoundation import from Engine.swift

### DIFF
--- a/Mythic/Utilities/Engine/Engine.swift
+++ b/Mythic/Utilities/Engine/Engine.swift
@@ -8,7 +8,6 @@
 import Foundation
 import OSLog
 import SemanticVersion
-import ZIPFoundation
 
 final class Engine {
     private static let log = Logger(


### PR DESCRIPTION
This pull request makes a minor update to the `Engine.swift` file by removing an unused import statement. This helps keep the code clean and free of unnecessary dependencies.