### PR TITLE
AI SLOP: Add initial Steam support and storefront plumbing

### DIFF
--- a/Mythic.xcodeproj/project.pbxproj
+++ b/Mythic.xcodeproj/project.pbxproj
@@ -29,14 +29,17 @@
 		6A11927C2EC8C1F0005A3E05 /* EpicGamesGame.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A11927B2EC8C1E8005A3E05 /* EpicGamesGame.swift */; };
 		6A11927E2EC8C1FA005A3E05 /* LocalGame.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A11927D2EC8C1F5005A3E05 /* LocalGame.swift */; };
 		6A1192802EC8C208005A3E05 /* SteamGame.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A11927F2EC8C205005A3E05 /* SteamGame.swift */; };
+		7A1B2C3D2F12345600ABCDE1 /* Steam.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A1B2C3E2F12345600ABCDE1 /* Steam.swift */; };
 		6A1192822EC8C2D7005A3E05 /* Game+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A1192812EC8C2D4005A3E05 /* Game+Extensions.swift */; };
 		6A1192852EC8D4FD005A3E05 /* GameManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A1192842EC8D4FB005A3E05 /* GameManager.swift */; };
 		6A11928D2ECA011C005A3E05 /* LocalGameManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A11928C2ECA0114005A3E05 /* LocalGameManager.swift */; };
 		6A11928F2ECA15C9005A3E05 /* EpicGamesGameManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A11928E2ECA15AD005A3E05 /* EpicGamesGameManager.swift */; };
+		7A1B2C3F2F12345700ABCDE1 /* SteamGameManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A1B2C402F12345700ABCDE1 /* SteamGameManager.swift */; };
 		6A12FF8E2B73AC4E00AA948C /* Glur in Frameworks */ = {isa = PBXBuildFile; productRef = 6A12FF8D2B73AC4E00AA948C /* Glur */; };
 		6A1357B32CE4B0CD00B19213 /* SemanticVersion+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A1357B22CE4B0C900B19213 /* SemanticVersion+Extensions.swift */; };
 		6A18E6732EE6748400AA3B15 /* LocalGameImportView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A18E6712EE6748400AA3B15 /* LocalGameImportView.swift */; };
 		6A18E6742EE6748400AA3B15 /* EpicGamesGameImportView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A18E66F2EE6748400AA3B15 /* EpicGamesGameImportView.swift */; };
+		7A1B2C412F12345800ABCDE1 /* SteamGameImportView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A1B2C422F12345800ABCDE1 /* SteamGameImportView.swift */; };
 		6A18E6752EE6748400AA3B15 /* GameImportView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A18E6702EE6748400AA3B15 /* GameImportView.swift */; };
 		6A2935322BFCFAFD0035CE4B /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6A2934AE2BFCFAFD0035CE4B /* Preview Assets.xcassets */; };
 		6A2935352BFCFAFD0035CE4B /* Bundle+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A2934B32BFCFAFD0035CE4B /* Bundle+Extensions.swift */; };
@@ -171,13 +174,16 @@
 		6A11927D2EC8C1F5005A3E05 /* LocalGame.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalGame.swift; sourceTree = "<group>"; };
 		6A11927F2EC8C205005A3E05 /* SteamGame.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SteamGame.swift; sourceTree = "<group>"; };
 		6A1192812EC8C2D4005A3E05 /* Game+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Game+Extensions.swift"; sourceTree = "<group>"; };
+		7A1B2C3E2F12345600ABCDE1 /* Steam.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Steam.swift; sourceTree = "<group>"; };
 		6A1192842EC8D4FB005A3E05 /* GameManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameManager.swift; sourceTree = "<group>"; };
 		6A11928C2ECA0114005A3E05 /* LocalGameManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalGameManager.swift; sourceTree = "<group>"; };
 		6A11928E2ECA15AD005A3E05 /* EpicGamesGameManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EpicGamesGameManager.swift; sourceTree = "<group>"; };
+		7A1B2C402F12345700ABCDE1 /* SteamGameManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SteamGameManager.swift; sourceTree = "<group>"; };
 		6A1357B22CE4B0C900B19213 /* SemanticVersion+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SemanticVersion+Extensions.swift"; sourceTree = "<group>"; };
 		6A18E66F2EE6748400AA3B15 /* EpicGamesGameImportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EpicGamesGameImportView.swift; sourceTree = "<group>"; };
 		6A18E6702EE6748400AA3B15 /* GameImportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameImportView.swift; sourceTree = "<group>"; };
 		6A18E6712EE6748400AA3B15 /* LocalGameImportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalGameImportView.swift; sourceTree = "<group>"; };
+		7A1B2C422F12345800ABCDE1 /* SteamGameImportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SteamGameImportView.swift; sourceTree = "<group>"; };
 		6A2934AE2BFCFAFD0035CE4B /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		6A2934B32BFCFAFD0035CE4B /* Bundle+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Bundle+Extensions.swift"; sourceTree = "<group>"; };
 		6A2934B42BFCFAFD0035CE4B /* Color+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Color+Extensions.swift"; sourceTree = "<group>"; };
@@ -340,6 +346,7 @@
 				6A1192842EC8D4FB005A3E05 /* GameManager.swift */,
 				6A11928C2ECA0114005A3E05 /* LocalGameManager.swift */,
 				6A11928E2ECA15AD005A3E05 /* EpicGamesGameManager.swift */,
+				7A1B2C402F12345700ABCDE1 /* SteamGameManager.swift */,
 				6A2934BE2BFCFAFD0035CE4B /* Legendary */,
 			);
 			path = GameManager;
@@ -351,6 +358,7 @@
 				6A18E66F2EE6748400AA3B15 /* EpicGamesGameImportView.swift */,
 				6A18E6702EE6748400AA3B15 /* GameImportView.swift */,
 				6A18E6712EE6748400AA3B15 /* LocalGameImportView.swift */,
+				7A1B2C422F12345800ABCDE1 /* SteamGameImportView.swift */,
 			);
 			path = GameImportView;
 			sourceTree = "<group>";
@@ -418,6 +426,7 @@
 				6A2934C42BFCFAFD0035CE4B /* Wine */,
 				6A2934BB2BFCFAFD0035CE4B /* Extensions */,
 				6A2934C52BFCFAFD0035CE4B /* FileLocations.swift */,
+				7A1B2C3E2F12345600ABCDE1 /* Steam.swift */,
 				6ABE9B8F2EC0F059002DBE82 /* SparkleUpdateController.swift */,
 				6A2934C62BFCFAFD0035CE4B /* Global.swift */,
 				6A6EE1862DBA650F00870AC4 /* Migrator.swift */,
@@ -852,6 +861,8 @@
 				6A29353E2BFCFAFD0035CE4B /* LegendaryInterface+Extensions.swift in Sources */,
 				6A2960FC2CE0ED0D00917E90 /* EpicWebAuthView.swift in Sources */,
 				6A1192802EC8C208005A3E05 /* SteamGame.swift in Sources */,
+				7A1B2C3D2F12345600ABCDE1 /* Steam.swift in Sources */,
+				7A1B2C3F2F12345700ABCDE1 /* SteamGameManager.swift in Sources */,
 				6A2935432BFCFAFD0035CE4B /* FileLocations.swift in Sources */,
 				6A2961002CE1033200917E90 /* NSWindow+Extensions.swift in Sources */,
 				6A9FE1162CDEED7A00C36058 /* WhatsNewCollection.swift in Sources */,
@@ -882,6 +893,7 @@
 				6A18E6732EE6748400AA3B15 /* LocalGameImportView.swift in Sources */,
 				6A18E6742EE6748400AA3B15 /* EpicGamesGameImportView.swift in Sources */,
 				6A18E6752EE6748400AA3B15 /* GameImportView.swift in Sources */,
+				7A1B2C412F12345800ABCDE1 /* SteamGameImportView.swift in Sources */,
 				6AE18E072EBE04C300766258 /* WineInterface+Extensions.swift in Sources */,
 				6A11927C2EC8C1F0005A3E05 /* EpicGamesGame.swift in Sources */,
 				6A9ADCE82EC300C500D159A3 /* OperationButton.swift in Sources */,

--- a/Mythic/Utilities/Game/EpicGamesGame.swift
+++ b/Mythic/Utilities/Game/EpicGamesGame.swift
@@ -12,7 +12,12 @@ import AppKit
 
 class EpicGamesGame: Game {
     override var storefront: Storefront? { .epicGames }
-
+    override var supportsInstallation: Bool { true }
+    override var supportsLaunching: Bool { true }
+    override var supportsMoving: Bool { true }
+    override var supportsUninstallation: Bool { true }
+    override var supportsVerification: Bool { true }
+    
     override var computedVerticalImageURL: URL? { Legendary.getImageURL(gameID: self.id, type: .tall) }
     override var computedHorizontalImageURL: URL? { Legendary.getImageURL(gameID: self.id, type: .normal) }
 

--- a/Mythic/Utilities/Game/Game+Extensions.swift
+++ b/Mythic/Utilities/Game/Game+Extensions.swift
@@ -40,11 +40,13 @@ extension Game {
     /// Enumeration containing all available game storefronts.
     enum Storefront: CustomStringConvertible, CaseIterable, Codable, Hashable {
         case epicGames
+        case steam
         case local
-
+    
         var description: String {
             switch self {
             case .epicGames:    String(localized: "Epic Games")
+            case .steam:        String(localized: "Steam")
             case .local:        String(localized: "Local")
             }
         }

--- a/Mythic/Utilities/Game/Game.swift
+++ b/Mythic/Utilities/Game/Game.swift
@@ -22,6 +22,26 @@ import AppKit
         assertionFailure("Storefront must always be populated by subclasses, when accessed.")
         return nil
     }
+    
+    var supportsInstallation: Bool { false }
+    var supportsLaunching: Bool { false }
+    var supportsMoving: Bool { false }
+    var supportsUninstallation: Bool { false }
+    var supportsVerification: Bool { false }
+    
+    struct UnsupportedOperationError: LocalizedError {
+        let operation: String
+        let game: Game
+        let reason: String?
+    
+        var errorDescription: String? {
+            let storefrontDescription = game.storefront?.description ?? String(describing: type(of: game))
+            let baseMessage = "\(operation) is not supported for \(storefrontDescription) games."
+    
+            guard let reason else { return baseMessage }
+            return baseMessage + "\n" + reason
+        }
+    }
 
     // swiftlint:disable:next identifier_name
     internal final var _containerURL: URL?
@@ -185,16 +205,34 @@ import AppKit
         // swiftlint:disable:previous identifier_name
         assertionFailure("Subclasses should implement _verifyInstallation()")
     }
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        try container.encode(id, forKey: .id)
+        try container.encode(title, forKey: .title)
+        try container.encode(installationState, forKey: .installationState)
+        try container.encodeIfPresent(storefront, forKey: .storefront)
+        try container.encodeIfPresent(_verticalImageURL, forKey: ._verticalImageURL)
+        try container.encodeIfPresent(_horizontalImageURL, forKey: ._horizontalImageURL)
+        try container.encodeIfPresent(_containerURL, forKey: ._containerURL)
+        try container.encode(launchArguments, forKey: .launchArguments)
+        try container.encode(isFavourited, forKey: .isFavourited)
+        try container.encodeIfPresent(lastLaunched, forKey: .lastLaunched)
+    }
+
 }
 
 extension Game: Equatable {
     public static func == (lhs: Game, rhs: Game) -> Bool {
-        return lhs.id == rhs.id
+        // Game IDs are only unique within a game source. Include the concrete type so
+        // different storefronts can safely use the same upstream identifier.
+        return type(of: lhs) == type(of: rhs) && lhs.id == rhs.id
     }
 }
 
 extension Game: Hashable {
     public func hash(into hasher: inout Hasher) {
+        hasher.combine(ObjectIdentifier(type(of: self)))
         hasher.combine(id)
     }
 }
@@ -221,20 +259,6 @@ extension Game {
              lastLaunched
     }
 
-    func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-
-        try container.encode(id, forKey: .id)
-        try container.encode(title, forKey: .title)
-        try container.encode(installationState, forKey: .installationState)
-        try container.encodeIfPresent(storefront, forKey: .storefront)
-        try container.encodeIfPresent(_verticalImageURL, forKey: ._verticalImageURL)
-        try container.encodeIfPresent(_horizontalImageURL, forKey: ._horizontalImageURL)
-        try container.encodeIfPresent(_containerURL, forKey: ._containerURL)
-        try container.encode(launchArguments, forKey: .launchArguments)
-        try container.encode(isFavourited, forKey: .isFavourited)
-        try container.encodeIfPresent(lastLaunched, forKey: .lastLaunched)
-    }
 }
 
 // note that merges should only be performed with the `identicalIgnoredKeys` requirement enforced.
@@ -274,6 +298,7 @@ struct AnyGame: Codable, Equatable {
             switch storefront {
             case .epicGames:    try EpicGamesGame(from: decoder)
             case .local:        try LocalGame(from: decoder)
+            case .steam:        try SteamGame(from: decoder)
             case nil:           try Game(from: decoder)
             }
         }()

--- a/Mythic/Utilities/Game/LocalGame.swift
+++ b/Mythic/Utilities/Game/LocalGame.swift
@@ -12,7 +12,9 @@ import OSLog
 
 class LocalGame: Game {
     override var storefront: Storefront? { .local }
-
+    override var supportsLaunching: Bool { true }
+    override var supportsMoving: Bool { true }
+    override var supportsUninstallation: Bool { true }
     override init(id: String = UUID().uuidString,
                   title: String,
                   installationState: InstallationState,
@@ -41,7 +43,9 @@ class LocalGame: Game {
     }
     
     override func _update() async throws {
-        assertionFailure("Attempted to update a LocalGame, which is not possible.")
+        throw UnsupportedOperationError(operation: "Updating",
+                                        game: self,
+                                        reason: "Manual games do not have a storefront update pipeline.")
     }
     
     override func _move(from currentLocation: URL,
@@ -50,6 +54,8 @@ class LocalGame: Game {
     }
     
     override func _verifyInstallation() async throws {
-        assertionFailure("Attempted to verify the installation of a LocalGame, which is not possible.")
+        throw UnsupportedOperationError(operation: "Verifying file integrity",
+                                        game: self,
+                                        reason: "Manual games do not have a storefront verification pipeline.")
     }
 }

--- a/Mythic/Utilities/Game/SteamGame.swift
+++ b/Mythic/Utilities/Game/SteamGame.swift
@@ -7,25 +7,102 @@
 
 // Copyright © 2023-2025 vapidinfinity
 
-// haha you thought
-
 import Foundation
 
-@available(*, deprecated, message: "Soon...")
 class SteamGame: Game {
+    enum CodingKeys: String, CodingKey {
+        case steamInstallationRootURL
+    }
+    
+    struct InstallationSource: Hashable {
+        let rootURL: URL
+        let containerURL: URL?
+    }
+    
+    override var storefront: Storefront? { .steam }
+    override var supportsLaunching: Bool { SteamGameManager.canLaunch(game: self) }
+    override var computedVerticalImageURL: URL? {
+        Steam.artworkURL(forAppID: id, kind: .verticalLibraryCapsule)
+    }
+    override var computedHorizontalImageURL: URL? {
+        Steam.artworkURL(forAppID: id, kind: .horizontalLibraryHero)
+    }
+    
+    var steamInstallationRootURL: URL?
+    
+    var installationSource: InstallationSource? {
+        guard let steamInstallationRootURL else { return nil }
+    
+        let normalizedRootURL = steamInstallationRootURL.standardizedFileURL
+        let importedContainerURL: URL? = _containerURL.flatMap { candidate -> URL? in
+            let normalizedContainerURL = candidate.standardizedFileURL
+            guard normalizedRootURL.path.hasPrefix(normalizedContainerURL.path) else { return nil }
+            return normalizedContainerURL
+        }
+    
+        return .init(rootURL: normalizedRootURL, containerURL: importedContainerURL)
+    }
+    
+    init(manifest: Steam.AppManifest, steamInstallationRootURL: URL, containerURL: URL? = nil) {
+        self.steamInstallationRootURL = steamInstallationRootURL.standardizedFileURL
+        
+        // Steam manifests do not expose enough metadata to distinguish Windows installs
+        // from other platform builds. Imported Steam support in Mythic targets existing
+        // Windows Steam libraries inside Wine containers, so these installs are modelled
+        // as Windows games.
+        super.init(id: manifest.appID,
+                   title: manifest.name,
+                   installationState: .installed(location: manifest.installationURL, platform: .windows),
+                   containerURL: containerURL)
+    }
+    
     override init(id: String = UUID().uuidString,
                   title: String,
                   installationState: InstallationState,
                   containerURL: URL? = nil) {
+        self.steamInstallationRootURL = nil
         super.init(id: id,
                    title: title,
                    installationState: installationState,
                    containerURL: containerURL)
     }
-
+    
     required init(from decoder: any Decoder) throws {
-        // super.init(from:) handles all decoding including subclass routing
-        // say 'thank you, super.init❤️'
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.steamInstallationRootURL = try container.decodeIfPresent(URL.self, forKey: .steamInstallationRootURL)?.standardizedFileURL
+        
+        // super.init(from:) handles all Game decoding, while SteamGame restores its
+        // installation root so refresh and launch can keep using the same Steam client.
         try super.init(from: decoder)
+    }
+    
+    override func encode(to encoder: any Encoder) throws {
+        try super.encode(to: encoder)
+        
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(steamInstallationRootURL, forKey: .steamInstallationRootURL)
+    }
+    
+    override func _launch() async throws {
+        try await SteamGameManager.launch(game: self)
+    }
+    
+    override func _update() async throws {
+        throw UnsupportedOperationError(operation: "Updating",
+                                        game: self,
+                                        reason: "Steam update integration is not implemented yet.")
+    }
+    
+    override func _move(from currentLocation: URL,
+                        to newLocation: URL) async throws {
+        throw UnsupportedOperationError(operation: "Moving",
+                                        game: self,
+                                        reason: "Steam library relocation is not implemented yet.")
+    }
+    
+    override func _verifyInstallation() async throws {
+        throw UnsupportedOperationError(operation: "Verifying file integrity",
+                                        game: self,
+                                        reason: "Steam verification is not implemented yet.")
     }
 }

--- a/Mythic/Utilities/GameDataStore.swift
+++ b/Mythic/Utilities/GameDataStore.swift
@@ -81,22 +81,94 @@ import OSLog
                     library.update(with: game)
                 }
                 
-                // installed: merge instead of overwrite
-                for fetchedGame in installed {
-                    if let existing = library.first(where: { $0 == fetchedGame }) {
-                        try existing.merge(with: fetchedGame, requiring: .identicalIgnoredKeys)
-                        library.update(with: existing)
-                    } else {
-                        library.update(with: fetchedGame)
-                    }
-                }
+                try mergeInstalledGames(installed)
             } catch {
                 log.error("Unable to refresh game data from Epic Games: \(error.localizedDescription)")
                 throw error
             }
         }
         
-        // TODO: others
-        // if storefronts.contains(...) { ... }
+        if storefronts.contains(.steam) {
+            do {
+                let sources = steamSourcesToRefresh()
+                guard !sources.isEmpty else {
+                    log.debug("Skipping Steam refresh because no Steam library metadata is available.")
+                    return
+                }
+    
+                var installed: [SteamGame] = []
+                for source in sources {
+                    installed += try Steam.getInstalledGames(in: source.rootURL, containerURL: source.containerURL)
+                }
+    
+                try reconcileSteamInstalledGames(installed)
+            } catch let error as Steam.Error {
+                switch error {
+                case .defaultRootUnavailable, .missingLibraryFoldersFile:
+                    log.debug("Skipping Steam refresh because no Steam library metadata is available.")
+                default:
+                    log.error("Unable to refresh game data from Steam: \(error.localizedDescription)")
+                    throw error
+                }
+            } catch {
+                log.error("Unable to refresh game data from Steam: \(error.localizedDescription)")
+                throw error
+            }
+        }
     }
+    
+    private func mergeInstalledGames<S: Sequence>(_ fetchedGames: S) throws where S.Element: Game {
+        for fetchedGame in fetchedGames {
+            if let existing = library.first(where: { $0 == fetchedGame }) {
+                try existing.merge(with: fetchedGame, requiring: .identicalIgnoredKeys)
+                library.update(with: existing)
+            } else {
+                library.update(with: fetchedGame)
+            }
+        }
+    }
+    
+    private func steamSourcesToRefresh() -> [SteamGame.InstallationSource] {
+        var sources: [SteamGame.InstallationSource] = []
+    
+        if let steamRootURL = Steam.rootURL,
+           Steam.containsLibraryMetadata(in: steamRootURL) {
+            sources.append(.init(rootURL: steamRootURL.standardizedFileURL, containerURL: nil))
+        }
+    
+        for game in library.compactMap({ $0 as? SteamGame }) {
+            guard let installationSource = game.installationSource, !sources.contains(installationSource) else { continue }
+            sources.append(installationSource)
+        }
+    
+        return sources
+    }
+    
+    private func upsertSteamGames(_ fetchedGames: [SteamGame]) throws {
+        for fetchedGame in fetchedGames {
+            if let existing = library.first(where: { $0 == fetchedGame }) as? SteamGame {
+                try existing.merge(with: fetchedGame, requiring: .identicalIgnoredKeys)
+                existing.steamInstallationRootURL = fetchedGame.steamInstallationRootURL
+                existing._containerURL = fetchedGame._containerURL
+                library.update(with: existing)
+            } else {
+                library.update(with: fetchedGame)
+            }
+        }
+    }
+    
+    private func reconcileSteamInstalledGames(_ fetchedGames: [SteamGame]) throws {
+        try upsertSteamGames(fetchedGames)
+    
+        // Steam support currently models only discovered installed titles. After a
+        // successful manifest refresh, any Steam entry missing from the current app
+        // manifest set is stale and should be removed rather than left pretending to
+        // reflect current installation state.
+        let fetchedIDs = Set(fetchedGames.map(\.id))
+        library = Set(library.filter { game in
+            guard game is SteamGame else { return true }
+            return fetchedIDs.contains(game.id)
+        })
+    }
+
 }

--- a/Mythic/Utilities/GameManager/SteamGameManager.swift
+++ b/Mythic/Utilities/GameManager/SteamGameManager.swift
@@ -1,0 +1,211 @@
+//
+//  SteamGameManager.swift
+//  Mythic
+//
+//  Created on 12/3/2026.
+//
+
+// Copyright © 2023-2025 vapidinfinity
+
+import Foundation
+import AppKit
+import OSLog
+
+extension SteamGameManager: StorefrontGameManager {
+    @MainActor static func importGame(_ game: Game, platform: Game.Platform, at location: URL) async throws {
+        guard case .steam = game.storefront,
+              let castGame = game as? SteamGame else { throw CocoaError(.coderInvalidValue) }
+    
+        try await importGame(castGame, in: location, platform: platform)
+    }
+    
+    static func install(game: Game, qualityOfService: QualityOfService) async throws -> GameOperation {
+        guard case .steam = game.storefront,
+              let castGame = game as? SteamGame else { throw CocoaError(.coderInvalidValue) }
+    
+        throw unsupportedOperationError("Installing", game: castGame, reason: "Steam install integration is not implemented yet.")
+    }
+    
+    static func update(game: Game, qualityOfService: QualityOfService) async throws -> GameOperation {
+        guard case .steam = game.storefront,
+              let castGame = game as? SteamGame else { throw CocoaError(.coderInvalidValue) }
+    
+        throw unsupportedOperationError("Updating", game: castGame, reason: "Steam update integration is not implemented yet.")
+    }
+    
+    static func repair(game: Game, qualityOfService: QualityOfService) async throws -> GameOperation {
+        guard case .steam = game.storefront,
+              let castGame = game as? SteamGame else { throw CocoaError(.coderInvalidValue) }
+    
+        throw unsupportedOperationError("Verifying file integrity", game: castGame, reason: "Steam verification is not implemented yet.")
+    }
+    
+    static func fetchUpdateAvailability(for game: Game) throws -> Bool {
+        guard case .steam = game.storefront,
+              let castGame = game as? SteamGame else { throw CocoaError(.coderInvalidValue) }
+    
+        throw unsupportedOperationError("Checking for updates", game: castGame, reason: "Steam update integration is not implemented yet.")
+    }
+    
+    static func isFileVerificationRequired(for game: Game) throws -> Bool {
+        guard case .steam = game.storefront,
+              let castGame = game as? SteamGame else { throw CocoaError(.coderInvalidValue) }
+    
+        throw unsupportedOperationError("Checking file integrity requirements", game: castGame, reason: "Steam verification integration is not implemented yet.")
+    }
+    
+    @MainActor static func launch(game: Game) async throws -> GameOperation {
+        guard case .steam = game.storefront,
+              let castGame = game as? SteamGame else { throw CocoaError(.coderInvalidValue) }
+    
+        return try await launch(game: castGame)
+    }
+    
+    @MainActor static func move(game: Game, to newLocation: URL) async throws -> GameOperation {
+        guard case .steam = game.storefront,
+              let castGame = game as? SteamGame else { throw CocoaError(.coderInvalidValue) }
+    
+        throw unsupportedOperationError("Moving", game: castGame, reason: "Steam library relocation is not implemented yet.")
+    }
+    
+    @MainActor static func uninstall(game: Game, persistFiles: Bool) async throws -> GameOperation {
+        guard case .steam = game.storefront,
+              let castGame = game as? SteamGame else { throw CocoaError(.coderInvalidValue) }
+    
+        throw unsupportedOperationError("Uninstalling", game: castGame, reason: "Steam uninstall integration is not implemented yet.")
+    }
+}
+
+final class SteamGameManager {
+    static var log: Logger { .custom(category: "SteamGameManager") }
+    
+    struct MissingWindowsSteamExecutableError: LocalizedError {
+        let steamRootURL: URL
+    
+        var errorDescription: String? {
+            "The selected Steam installation does not contain steam.exe at \(Steam.windowsExecutableURL(in: steamRootURL).prettyPath)."
+        }
+    }
+    
+    struct GameNotFoundInSteamLibraryError: LocalizedError {
+        let gameID: String
+        let steamRootURL: URL
+    
+        var errorDescription: String? {
+            "Steam game \(gameID) was not found in \(steamRootURL.prettyPath)."
+        }
+    }
+    
+    private static func unsupportedOperationError(_ operation: String, game: SteamGame, reason: String) -> Game.UnsupportedOperationError {
+        .init(operation: operation, game: game, reason: reason)
+    }
+    
+    /// Steam launch has two truthful paths in Mythic today:
+    /// 1. Native macOS Steam via the `steam://` protocol.
+    /// 2. Existing Windows Steam installs inside a Wine container, launched through
+    ///    that container's `steam.exe -applaunch <appid>` command line.
+    static func canLaunch(game: SteamGame) -> Bool {
+        guard case .installed = game.installationState,
+              let source = game.installationSource else { return false }
+    
+        if let containerURL = source.containerURL {
+            return Wine.containerURLs.contains(containerURL)
+                && FileManager.default.fileExists(atPath: Steam.windowsExecutableURL(in: source.rootURL).path)
+        }
+    
+        guard Steam.isClientInstalled else { return false }
+        return (try? Steam.launchURL(forAppID: game.id, launchArguments: game.launchArguments)) != nil
+    }
+    
+    @MainActor static func importGame(_ game: SteamGame,
+                                      in steamRootURL: URL,
+                                      platform: Game.Platform) async throws {
+        guard case .windows = platform else {
+            throw unsupportedOperationError("Importing", game: game, reason: "Mythic currently imports Steam games only from Windows Steam libraries.")
+        }
+    
+        let normalizedSteamRootURL = steamRootURL.standardizedFileURL
+        guard Steam.containsLibraryMetadata(in: normalizedSteamRootURL) else {
+            throw Steam.Error.missingLibraryFoldersFile(normalizedSteamRootURL.appending(path: "steamapps").appending(path: "libraryfolders.vdf"))
+        }
+    
+        guard let selectedContainerURL = game.installationSource?.containerURL else {
+            throw unsupportedOperationError("Importing", game: game, reason: "Select the Wine container that owns this Windows Steam installation before importing.")
+        }
+    
+        guard normalizedSteamRootURL.path.hasPrefix(selectedContainerURL.standardizedFileURL.path) else {
+            throw unsupportedOperationError("Importing", game: game, reason: "The selected Steam root must live inside the chosen Wine container.")
+        }
+    
+        let steamExecutableURL = Steam.windowsExecutableURL(in: normalizedSteamRootURL)
+        guard FileManager.default.fileExists(atPath: steamExecutableURL.path) else {
+            throw MissingWindowsSteamExecutableError(steamRootURL: normalizedSteamRootURL)
+        }
+    
+        let importedGames = try Steam.getInstalledGames(in: normalizedSteamRootURL, containerURL: selectedContainerURL)
+        guard let importedGame = importedGames.first(where: { $0.id == game.id }) else {
+            throw GameNotFoundInSteamLibraryError(gameID: game.id, steamRootURL: normalizedSteamRootURL)
+        }
+    
+        if let existing = GameDataStore.shared.library.first(where: { $0 == importedGame }) as? SteamGame {
+            try existing.merge(with: importedGame, requiring: .identicalIgnoredKeys)
+            existing.steamInstallationRootURL = importedGame.steamInstallationRootURL
+            existing._containerURL = importedGame._containerURL
+            GameDataStore.shared.library.update(with: existing)
+        } else {
+            GameDataStore.shared.library.update(with: importedGame)
+        }
+    }
+    
+    @discardableResult
+    @MainActor static func launch(game: SteamGame) async throws -> GameOperation {
+        guard case .installed = game.installationState else {
+            throw CocoaError(.fileNoSuchFile)
+        }
+    
+        guard let source = game.installationSource else {
+            throw unsupportedOperationError("Launching", game: game, reason: "This Steam game does not have a known Steam installation root.")
+        }
+    
+        if let containerURL = source.containerURL {
+            let steamExecutableURL = Steam.windowsExecutableURL(in: source.rootURL)
+            guard FileManager.default.fileExists(atPath: steamExecutableURL.path) else {
+                throw MissingWindowsSteamExecutableError(steamRootURL: source.rootURL)
+            }
+    
+            let operation: GameOperation = .init(game: game, type: .launch) { _ in
+                let process: Process = .init()
+                process.arguments = [steamExecutableURL.path, "-silent", "-applaunch", game.id] + game.launchArguments
+                Wine.transformProcess(process, containerURL: containerURL)
+    
+                try process.run()
+    
+                if UserDefaults.standard.bool(forKey: "minimiseOnGameLaunch") {
+                    await MainActor.run {
+                        NSApp.windows.first?.miniaturize(nil)
+                    }
+                }
+            }
+    
+            Game.operationManager.queueOperation(operation)
+            return operation
+        }
+    
+        guard Steam.isClientInstalled else { throw Steam.Error.clientNotInstalled }
+        let launchURL = try Steam.launchURL(forAppID: game.id, launchArguments: game.launchArguments)
+    
+        let operation: GameOperation = .init(game: game, type: .launch) { _ in
+            let didOpen = await MainActor.run { NSWorkspace.shared.open(launchURL) }
+            guard didOpen else { throw Steam.Error.unableToOpenLaunchURL(launchURL) }
+    
+            if UserDefaults.standard.bool(forKey: "minimiseOnGameLaunch") {
+                await MainActor.run {
+                    NSApp.windows.first?.miniaturize(nil)
+                }
+            }
+        }
+    
+        Game.operationManager.queueOperation(operation)
+        return operation
+    }
+}

--- a/Mythic/Utilities/SparkleUpdateController.swift
+++ b/Mythic/Utilities/SparkleUpdateController.swift
@@ -24,8 +24,8 @@ final class SparkleUpdateController: NSObject, SPUUserDriver, ObservableObject {
 
     private var updateSettingsCancellables: Set<AnyCancellable> = []
     private var backgroundTask: AnyCancellable?
-    private let backgroundQueue: DispatchQueue = .init(label: "BackgroudEventService", qos: .background)
-
+    private static let backgroundCheckInterval: TimeInterval = 60 * 60 * 6
+    
     override init() {
         super.init()
 
@@ -47,20 +47,19 @@ final class SparkleUpdateController: NSObject, SPUUserDriver, ObservableObject {
     }
 
     private func manageBackgroundTask(_ enabled: Bool) {
-        if enabled {
-            backgroundTask = AnyCancellable(
-                backgroundQueue.schedule(
-                    after: .init(.now()),
-                    interval: .seconds(60 * 60 * 6)
-                ) {
-                    Task { @MainActor in
-                        SparkleUpdateController.shared.checkForUpdates(userInitiated: false)
-                    }
-                }
-            )
-        } else {
-            backgroundTask?.cancel()
-        }
+        backgroundTask?.cancel()
+        backgroundTask = nil
+
+        guard enabled else { return }
+
+        // Sparkle state is surfaced through SwiftUI and must stay on the main actor.
+        // A main-run-loop timer avoids dispatch queue / executor mismatches at startup.
+        checkForUpdates(userInitiated: false)
+        backgroundTask = Timer.publish(every: Self.backgroundCheckInterval, on: .main, in: .common)
+            .autoconnect()
+            .sink { [weak self] _ in
+                self?.checkForUpdates(userInitiated: false)
+            }
     }
 
     func clearState() -> Bool {

--- a/Mythic/Utilities/Steam.swift
+++ b/Mythic/Utilities/Steam.swift
@@ -1,0 +1,416 @@
+//
+//  Steam.swift
+//  Mythic
+//
+//  Created on 12/3/2026.
+//
+
+// Copyright © 2023-2025 vapidinfinity
+
+import Foundation
+import AppKit
+
+enum Steam {
+    static let rootPathUserDefaultsKey = "steamRootPath"
+    
+    static var configuredRootURL: URL? {
+        guard let path = UserDefaults.standard.string(forKey: rootPathUserDefaultsKey)?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+              !path.isEmpty else {
+            return nil
+        }
+        
+        return URL(fileURLWithPath: NSString(string: path).expandingTildeInPath, isDirectory: true)
+    }
+    
+    /// Default Steam installation root on macOS.
+    static var defaultRootURL: URL? {
+        let fileManager: FileManager = .default
+        guard let applicationSupportURL = try? fileManager.url(for: .applicationSupportDirectory,
+                                                               in: .userDomainMask,
+                                                               appropriateFor: nil,
+                                                               create: false) else {
+            return nil
+        }
+        
+        let steamURL = applicationSupportURL.appending(path: "Steam")
+        guard fileManager.fileExists(atPath: steamURL.path) else { return nil }
+        return steamURL
+    }
+    
+    static var rootURL: URL? { configuredRootURL ?? defaultRootURL }
+    static var isUsingCustomRootURL: Bool { configuredRootURL != nil }
+    static let browserProtocolURL: URL = .init(string: "steam://")! // swiftlint:disable:this force_unwrapping
+    static var isClientInstalled: Bool { NSWorkspace.shared.urlForApplication(toOpen: browserProtocolURL) != nil }
+    
+    static func containsLibraryMetadata(in steamRootURL: URL? = nil) -> Bool {
+        guard let candidateRootURL = steamRootURL ?? rootURL else { return false }
+        let libraryFoldersURL = candidateRootURL.appending(path: "steamapps").appending(path: "libraryfolders.vdf")
+        return FileManager.default.fileExists(atPath: libraryFoldersURL.path)
+    }
+    
+    enum ArtworkKind {
+        case verticalLibraryCapsule
+        case horizontalLibraryHero
+    
+        fileprivate var assetName: String {
+            switch self {
+            case .verticalLibraryCapsule: "library_600x900_2x.jpg"
+            case .horizontalLibraryHero:  "library_hero.jpg"
+            }
+        }
+    }
+    
+    /// Best-effort public library artwork URL. Steam's newer hashed asset pipeline
+    /// is richer, but this legacy CDN pattern covers many titles without extra API calls.
+    static func artworkURL(forAppID appID: String, kind: ArtworkKind) -> URL? {
+        guard !appID.isEmpty, appID.allSatisfy(\.isNumber) else { return nil }
+        return URL(string: "https://steamcdn-a.akamaihd.net/steam/apps/\(appID)/\(kind.assetName)")
+    }
+    
+    static func windowsExecutableURL(in steamRootURL: URL) -> URL {
+        steamRootURL.appending(path: "steam.exe")
+    }
+    
+    static func launchURL(forAppID appID: String, launchArguments: [String] = []) throws -> URL {
+        guard !appID.isEmpty, appID.allSatisfy(\.isNumber) else {
+            throw Error.invalidAppID(appID)
+        }
+        
+        if launchArguments.isEmpty {
+            // Delegate startup to the installed Steam client instead of attempting to
+            // execute a Steam-managed binary directly. Steam owns DRM/bootstrap flow.
+            return .init(string: "steam://rungameid/\(appID)")! // swiftlint:disable:this force_unwrapping
+        }
+        
+        var allowedCharacters = CharacterSet.urlPathAllowed
+        allowedCharacters.remove(charactersIn: "/")
+        guard let encodedArguments = launchArguments.joined(separator: " ")
+            .addingPercentEncoding(withAllowedCharacters: allowedCharacters),
+              let url = URL(string: "steam://run/\(appID)//\(encodedArguments)/") else {
+            throw Error.invalidLaunchArguments(launchArguments)
+        }
+        
+        return url
+    }
+
+    struct LibraryFolder: Hashable {
+        let url: URL
+
+        var steamAppsURL: URL { url.appending(path: "steamapps") }
+        var commonURL: URL { steamAppsURL.appending(path: "common") }
+    }
+
+    struct AppManifest: Hashable {
+        let appID: String
+        let name: String
+        let installDirectoryName: String
+        let libraryURL: URL
+        let manifestURL: URL
+        let buildID: String?
+        let stateFlags: Int?
+        let sizeOnDiskInBytes: Int64?
+
+        var installationURL: URL {
+            libraryURL
+                .appending(path: "steamapps")
+                .appending(path: "common")
+                .appending(path: installDirectoryName)
+        }
+    }
+
+    enum Error: LocalizedError {
+        case defaultRootUnavailable
+        case missingLibraryFoldersFile(URL)
+        case missingSteamAppsDirectory(URL)
+        case missingRequiredValue(file: URL, keyPath: String)
+        case invalidVDF(file: URL, reason: String)
+        case invalidAppID(String)
+        case invalidLaunchArguments([String])
+        case clientNotInstalled
+        case unableToOpenLaunchURL(URL)
+        case windowsPathRequiresContainer(String)
+    
+        var errorDescription: String? {
+            switch self {
+            case .defaultRootUnavailable:
+                return "Steam is not installed in the default macOS location."
+            case .missingLibraryFoldersFile(let file):
+                return "Steam library metadata is missing at \(file.path)."
+            case .missingSteamAppsDirectory(let directory):
+                return "Steam library folder is missing its steamapps directory at \(directory.path)."
+            case .missingRequiredValue(let file, let keyPath):
+                return "Steam metadata file \(file.lastPathComponent) is missing required key \(keyPath)."
+            case .invalidVDF(let file, let reason):
+                return "Unable to parse Steam metadata file \(file.lastPathComponent): \(reason)"
+            case .invalidAppID(let appID):
+                return "Steam app ID \(appID) is invalid."
+            case .invalidLaunchArguments(let arguments):
+                return "Steam launch arguments could not be encoded: \(arguments.joined(separator: " "))"
+            case .clientNotInstalled:
+                return "Steam is not installed or has not registered the steam:// URL scheme."
+            case .unableToOpenLaunchURL(let url):
+                return "Unable to open Steam launch URL \(url.absoluteString)."
+            case .windowsPathRequiresContainer(let path):
+                return "The Windows Steam library path \(path) requires a Wine container to resolve on macOS."
+            }
+        }
+    }
+
+    /// Enumerate every Steam library root listed in `libraryfolders.vdf`.
+    static func getLibraryFolders(in steamRootURL: URL? = nil, containerURL: URL? = nil) throws -> [LibraryFolder] {
+        let fileManager: FileManager = .default
+        let steamRootURL = try resolveSteamRootURL(from: steamRootURL)
+        let libraryFoldersURL = steamRootURL.appending(path: "steamapps").appending(path: "libraryfolders.vdf")
+    
+        guard fileManager.fileExists(atPath: libraryFoldersURL.path) else {
+            throw Error.missingLibraryFoldersFile(libraryFoldersURL)
+        }
+    
+        let vdf = try parseVDF(at: libraryFoldersURL)
+        guard let libraryFolders = vdf["libraryfolders"]?.objectValue else {
+            throw Error.missingRequiredValue(file: libraryFoldersURL, keyPath: "libraryfolders")
+        }
+    
+        return try libraryFolders
+            .filter { $0.key.allSatisfy(\.isNumber) }
+            .sorted(by: { lhs, rhs in lhs.key < rhs.key })
+            .map { _, value in
+                guard let folder = value.objectValue,
+                      let path = folder["path"]?.stringValue else {
+                    throw Error.missingRequiredValue(file: libraryFoldersURL, keyPath: "libraryfolders.<index>.path")
+                }
+    
+                let resolvedPath = try resolveLibraryFolderPath(path, containerURL: containerURL)
+                return LibraryFolder(url: resolvedPath)
+            }
+    }
+    
+    /// Parse every `appmanifest_<appid>.acf` file across all configured Steam libraries.
+    static func getInstalledApps(in steamRootURL: URL? = nil, containerURL: URL? = nil) throws -> [AppManifest] {
+        let fileManager: FileManager = .default
+    
+        return try getLibraryFolders(in: steamRootURL, containerURL: containerURL).flatMap { libraryFolder in
+            guard fileManager.fileExists(atPath: libraryFolder.steamAppsURL.path) else {
+                throw Error.missingSteamAppsDirectory(libraryFolder.steamAppsURL)
+            }
+    
+            let manifestURLs = try fileManager.contentsOfDirectory(at: libraryFolder.steamAppsURL,
+                                                                   includingPropertiesForKeys: nil,
+                                                                   options: [.skipsHiddenFiles])
+                .filter { $0.pathExtension == "acf" && $0.lastPathComponent.hasPrefix("appmanifest_") }
+                .sorted(by: { $0.lastPathComponent < $1.lastPathComponent })
+    
+            return try manifestURLs.map { try parseAppManifest(at: $0, libraryURL: libraryFolder.url) }
+        }
+    }
+    
+    static func getInstalledGames(in steamRootURL: URL? = nil, containerURL: URL? = nil) throws -> [SteamGame] {
+        let steamRootURL = try resolveSteamRootURL(from: steamRootURL)
+        return try getInstalledApps(in: steamRootURL, containerURL: containerURL)
+            .map { SteamGame(manifest: $0, steamInstallationRootURL: steamRootURL, containerURL: containerURL) }
+    }
+
+    private static func resolveSteamRootURL(from explicitURL: URL?) throws -> URL {
+        if let explicitURL { return explicitURL }
+        guard let rootURL else { throw Error.defaultRootUnavailable }
+        return rootURL
+    }
+    private static func resolveLibraryFolderPath(_ rawPath: String, containerURL: URL?) throws -> URL {
+        let expandedPath = NSString(string: rawPath).expandingTildeInPath
+        let normalizedWindowsPath = expandedPath.replacingOccurrences(of: "\\", with: "/")
+    
+        let windowsDriveRegex = try! Regex(#"^(?<drive>[A-Za-z]):(?<path>/.*)?$"#) // swiftlint:disable:this force_try
+        if let match = try? windowsDriveRegex.firstMatch(in: normalizedWindowsPath),
+           let driveSubstring = match["drive"]?.substring {
+            let drive = driveSubstring.lowercased()
+            guard let containerURL else { throw Error.windowsPathRequiresContainer(rawPath) }
+    
+            let relativePath = String(match["path"]?.substring ?? "")
+                .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+            let baseURL: URL = if drive == "c" {
+                containerURL.appending(path: "drive_c")
+            } else {
+                containerURL.appending(path: "dosdevices").appending(path: "\(drive):")
+            }
+    
+            return relativePath.isEmpty ? baseURL : baseURL.appending(path: relativePath)
+        }
+    
+        return URL(fileURLWithPath: expandedPath)
+    }
+
+
+    private static func parseAppManifest(at manifestURL: URL, libraryURL: URL) throws -> AppManifest {
+        let vdf = try parseVDF(at: manifestURL)
+        guard let appState = vdf["AppState"]?.objectValue else {
+            throw Error.missingRequiredValue(file: manifestURL, keyPath: "AppState")
+        }
+
+        guard let appID = appState["appid"]?.stringValue else {
+            throw Error.missingRequiredValue(file: manifestURL, keyPath: "AppState.appid")
+        }
+
+        guard let name = appState["name"]?.stringValue else {
+            throw Error.missingRequiredValue(file: manifestURL, keyPath: "AppState.name")
+        }
+
+        guard let installDirectoryName = appState["installdir"]?.stringValue else {
+            throw Error.missingRequiredValue(file: manifestURL, keyPath: "AppState.installdir")
+        }
+
+        return AppManifest(appID: appID,
+                           name: name,
+                           installDirectoryName: installDirectoryName,
+                           libraryURL: libraryURL,
+                           manifestURL: manifestURL,
+                           buildID: appState["buildid"]?.stringValue,
+                           stateFlags: Int(appState["StateFlags"]?.stringValue ?? ""),
+                           sizeOnDiskInBytes: Int64(appState["SizeOnDisk"]?.stringValue ?? ""))
+    }
+
+    private static func parseVDF(at url: URL) throws -> [String: VDFValue] {
+        let source = try String(contentsOf: url, encoding: .utf8)
+        var parser = VDFParser(source: source, sourceURL: url)
+        return try parser.parse()
+    }
+}
+
+private enum VDFValue: Hashable {
+    case string(String)
+    case object([String: VDFValue])
+
+    var stringValue: String? {
+        guard case let .string(value) = self else { return nil }
+        return value
+    }
+
+    var objectValue: [String: VDFValue]? {
+        guard case let .object(value) = self else { return nil }
+        return value
+    }
+}
+
+private struct VDFParser {
+    let source: String
+    let sourceURL: URL
+    private var index: String.Index
+
+    init(source: String, sourceURL: URL) {
+        self.source = source
+        self.sourceURL = sourceURL
+        index = source.startIndex
+    }
+
+    mutating func parse() throws -> [String: VDFValue] {
+        let object = try parseObjectBody(untilClosingBrace: false)
+        skipIgnorableCharacters()
+
+        guard index == source.endIndex else {
+            throw Steam.Error.invalidVDF(file: sourceURL, reason: "unexpected trailing characters")
+        }
+
+        return object
+    }
+
+    private mutating func parseObjectBody(untilClosingBrace: Bool) throws -> [String: VDFValue] {
+        var object: [String: VDFValue] = [:]
+
+        while true {
+            skipIgnorableCharacters()
+
+            if index == source.endIndex {
+                if untilClosingBrace {
+                    throw Steam.Error.invalidVDF(file: sourceURL, reason: "unterminated object")
+                }
+
+                return object
+            }
+
+            if untilClosingBrace, peek() == "}" {
+                advanceIndex()
+                return object
+            }
+
+            let key = try parseQuotedString()
+            skipIgnorableCharacters()
+
+            if peek() == "{" {
+                advanceIndex()
+                object[key] = .object(try parseObjectBody(untilClosingBrace: true))
+                continue
+            }
+
+            object[key] = .string(try parseQuotedString())
+        }
+    }
+
+    private mutating func parseQuotedString() throws -> String {
+        guard peek() == "\"" else {
+            throw Steam.Error.invalidVDF(file: sourceURL, reason: "expected quoted string")
+        }
+
+        advanceIndex()
+        var output = String()
+
+        while index < source.endIndex {
+            let character = source[index]
+            advanceIndex()
+
+            switch character {
+            case "\\":
+                guard index < source.endIndex else {
+                    throw Steam.Error.invalidVDF(file: sourceURL, reason: "unterminated escape sequence")
+                }
+
+                let escapedCharacter = source[index]
+                advanceIndex()
+
+                switch escapedCharacter {
+                case "n": output.append("\n")
+                case "r": output.append("\r")
+                case "t": output.append("\t")
+                case "\\", "\"": output.append(escapedCharacter)
+                default: output.append(escapedCharacter)
+                }
+            case "\"":
+                return output
+            default:
+                output.append(character)
+            }
+        }
+
+        throw Steam.Error.invalidVDF(file: sourceURL, reason: "unterminated quoted string")
+    }
+
+    private mutating func skipIgnorableCharacters() {
+        while index < source.endIndex {
+            let character = source[index]
+
+            if character.isWhitespace {
+                advanceIndex()
+                continue
+            }
+
+            if character == "/",
+               source.index(after: index) < source.endIndex,
+               source[source.index(after: index)] == "/" {
+                while index < source.endIndex, source[index] != "\n" {
+                    advanceIndex()
+                }
+                continue
+            }
+
+            break
+        }
+    }
+
+    private func peek() -> Character? {
+        guard index < source.endIndex else { return nil }
+        return source[index]
+    }
+
+    private mutating func advanceIndex() {
+        index = source.index(after: index)
+    }
+}

--- a/Mythic/Views/Unified/Components/GameCard/GameCard+Extensions.swift
+++ b/Mythic/Views/Unified/Components/GameCard/GameCard+Extensions.swift
@@ -114,8 +114,7 @@ extension GameCard {
                                 .padding(2)
                         }
                     }
-                    .disabled(networkMonitor.epicAccessibilityState != .accessible)
-                    .disabled(game.storefront == .local)
+                    .disabled(!game.supportsInstallation || networkMonitor.epicAccessibilityState != .accessible)
                     .disabled(operationManager.queue.contains(where: { $0.game == game && $0.type == .install }))
                     .help("Install \(game.description)")
 
@@ -164,8 +163,7 @@ extension GameCard {
                             .padding(2)
                     }
                 }
-                .disabled(networkMonitor.epicAccessibilityState != .accessible)
-                .disabled(game.storefront == .local)
+                .disabled(!game.supportsVerification || networkMonitor.epicAccessibilityState != .accessible)
                 .disabled(operationManager.queue.contains(where: { $0.game == game && $0.type == .repair }))
                 .alert("Unable to verify installation.",
                        isPresented: $isVerificationErrorAlertPresented,
@@ -296,7 +294,7 @@ extension GameCard {
                             .padding(2)
                     }
                 }
-                .disabled(operationManager.queue.contains(where: { $0.game == game && $0.type == .uninstall }))
+                .disabled(!game.supportsUninstallation || operationManager.queue.contains(where: { $0.game == game && $0.type == .uninstall }))
                 // FIXME: .disabled(game.checkIfGameIsRunning())
                 .help("Delete \"\(game.title)\"")
                 .onHover { hovering in
@@ -326,7 +324,9 @@ extension GameCard {
                     GameCard.Buttons.SettingsButton(game: $game, withLabel: true, isGameSettingsSheetPresented: $isGameSettingsSheetPresented)
                     GameCard.Buttons.UpdateButton(game: $game, withLabel: true)
                     GameCard.Buttons.FavouriteButton(game: $game, withLabel: true)
-                    GameCard.Buttons.DeleteButton(game: $game, withLabel: true, isUninstallSheetPresented: $isUninstallSheetPresented)
+                    if game.supportsUninstallation {
+                        GameCard.Buttons.DeleteButton(game: $game, withLabel: true, isUninstallSheetPresented: $isUninstallSheetPresented)
+                    }
                 } label: {
                     Button { } label: {
                         Image(systemName: "ellipsis")
@@ -374,7 +374,10 @@ extension GameCard {
             if let operation = operationManager.queue.first(where: { $0.isExecuting && $0.game == game }) {
                 OperationCard.StatusView(operation: .constant(operation), withLabel: withLabel)
             } else if case .installed = game.installationState {
-                Buttons.Prominent.PlayButton(game: $game, withLabel: withLabel)
+                if game.supportsLaunching {
+                    Buttons.Prominent.PlayButton(game: $game, withLabel: withLabel)
+                }
+                
                 MenuView(game: $game)
                     .layoutPriority(1)
             } else {

--- a/Mythic/Views/Unified/Sheets/GameImportView/GameImportView.swift
+++ b/Mythic/Views/Unified/Sheets/GameImportView/GameImportView.swift
@@ -22,9 +22,8 @@ struct GameImportView: View {
                     }
                     
                     Tab("Steam", systemImage: "storefront") {
-
+                        SteamGameImportView(isPresented: $isPresented)
                     }
-                    .hidden()
                     
                     Tab("Local", systemImage: "storefront") {
                         LocalGameImportView(isPresented: $isPresented)
@@ -37,6 +36,10 @@ struct GameImportView: View {
                     EpicGamesGameImportView(isPresented: $isPresented)
                         .tabItem {
                             Label("Epic", systemImage: "storefront")
+                        }
+                    SteamGameImportView(isPresented: $isPresented)
+                        .tabItem {
+                            Label("Steam", systemImage: "storefront")
                         }
                     
                     LocalGameImportView(isPresented: $isPresented)

--- a/Mythic/Views/Unified/Sheets/GameImportView/SteamGameImportView.swift
+++ b/Mythic/Views/Unified/Sheets/GameImportView/SteamGameImportView.swift
@@ -1,0 +1,244 @@
+//
+//  SteamGameImportView.swift
+//  Mythic
+//
+//  Created on 12/3/2026.
+//
+
+// Copyright © 2023-2025 vapidinfinity
+
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct SteamGameImportView: View {
+    @Bindable var gameDataStore: GameDataStore = .shared
+
+    @Binding var isPresented: Bool
+
+    @State private var game: SteamGame = .init(title: "", installationState: .uninstalled)
+    @State private var discoveredGames: [SteamGame] = []
+
+    @State private var selectedContainerURL: URL? = Wine.containerURLs.first
+    @State private var steamRootURL: URL?
+
+    @State private var isImageEmpty: Bool = false
+    @State private var isSteamRootImporterPresented: Bool = false
+
+    @State private var isLoadingGames: Bool = false
+    @State private var isImporting: Bool = false
+    @State private var importSuccessful: Bool?
+
+    @State private var importError: Error?
+    @State private var isImportErrorAlertPresented: Bool = false
+
+    private var refreshKey: String {
+        "\(selectedContainerURL?.path ?? "")|\(steamRootURL?.path ?? "")"
+    }
+
+    private var selectedGameLocationDescription: String {
+        guard case .installed(let location, _) = game.installationState else { return "Unknown" }
+        return location.prettyPath
+    }
+
+    private var isSelectedSteamRootInContainer: Bool {
+        guard let steamRootURL, let selectedContainerURL else { return false }
+        return steamRootURL.standardizedFileURL.path.hasPrefix(selectedContainerURL.standardizedFileURL.path)
+    }
+
+    private var steamExecutableURL: URL? {
+        steamRootURL.map { Steam.windowsExecutableURL(in: $0) }
+    }
+
+    private var doesSelectedSteamRootContainClient: Bool {
+        guard let steamExecutableURL else { return false }
+        return FileManager.default.fileExists(atPath: steamExecutableURL.path)
+    }
+
+    private var isReadyToImport: Bool {
+        steamRootURL != nil
+            && selectedContainerURL != nil
+            && isSelectedSteamRootInContainer
+            && doesSelectedSteamRootContainClient
+            && discoveredGames.contains(where: { $0 == game })
+    }
+
+    private func suggestedContainerURL(for steamRootURL: URL) -> URL? {
+        Wine.containerURLs.first(where: { steamRootURL.standardizedFileURL.path.hasPrefix($0.standardizedFileURL.path) })
+    }
+
+    @MainActor
+    private func resetDiscoveredGames() {
+        discoveredGames = []
+        game = SteamGame(title: "", installationState: .uninstalled, containerURL: selectedContainerURL)
+    }
+
+    @MainActor
+    private func refreshDiscoveredGames() async {
+        guard let steamRootURL, let selectedContainerURL else {
+            resetDiscoveredGames()
+            return
+        }
+
+        isLoadingGames = true
+        defer { isLoadingGames = false }
+
+        do {
+            let fetchedGames = try Steam.getInstalledGames(in: steamRootURL, containerURL: selectedContainerURL)
+                .sorted(by: { $0.title.localizedCaseInsensitiveCompare($1.title) == .orderedAscending })
+
+            discoveredGames = fetchedGames
+
+            if let refreshedSelection = fetchedGames.first(where: { $0.id == game.id }) {
+                game = refreshedSelection
+            } else {
+                game = fetchedGames.first ?? SteamGame(title: "", installationState: .uninstalled, containerURL: selectedContainerURL)
+            }
+        } catch {
+            resetDiscoveredGames()
+            importError = error
+            isImportErrorAlertPresented = true
+        }
+    }
+
+    var body: some View {
+        VStack {
+            HStack {
+                GameImageCard(game: game, url: game.verticalImageURL, isImageEmpty: $isImageEmpty)
+                    .aspectRatio(3/4, contentMode: .fit)
+                    .padding([.top, .leading])
+
+                Form {
+                    if Wine.containerURLs.isEmpty {
+                        ContentUnavailableView(
+                            "No containers available.",
+                            systemImage: "cube.transparent",
+                            description: Text("Create a Wine container before importing a Windows Steam game.")
+                        )
+                    } else {
+                        Picker("Wine Container", systemImage: "cube", selection: $selectedContainerURL) {
+                            ForEach(Wine.containerObjects) { container in
+                                Text(container.name)
+                                    .tag(Optional(container.url))
+                            }
+                        }
+
+                        HStack {
+                            VStack(alignment: .leading) {
+                                Label("Steam Root", systemImage: "folder")
+                                Text(steamRootURL?.prettyPath ?? "Select the Steam folder inside a Wine container")
+                                    .foregroundStyle(.secondary)
+                            }
+
+                            if steamRootURL != nil && !isSelectedSteamRootInContainer {
+                                Image(systemName: "exclamationmark.triangle")
+                                    .symbolVariant(.fill)
+                                    .help("The selected Steam root must live inside the chosen Wine container.")
+                            } else if steamRootURL != nil && !doesSelectedSteamRootContainClient {
+                                Image(systemName: "exclamationmark.triangle")
+                                    .symbolVariant(.fill)
+                                    .help("The selected Steam folder must contain steam.exe.")
+                            }
+
+                            Spacer()
+
+                            Button("Browse...") {
+                                isSteamRootImporterPresented = true
+                            }
+                            .fileImporter(
+                                isPresented: $isSteamRootImporterPresented,
+                                allowedContentTypes: [.folder]
+                            ) { result in
+                                if case .success(let selectedURL) = result {
+                                    let normalizedURL = selectedURL.standardizedFileURL
+                                    steamRootURL = normalizedURL
+                                    if let suggestedContainerURL = suggestedContainerURL(for: normalizedURL) {
+                                        selectedContainerURL = suggestedContainerURL
+                                    }
+                                }
+                            }
+                        }
+                        .help("Select the Windows Steam folder that contains steam.exe and steamapps.")
+
+                        Picker("Game", systemImage: "gamecontroller", selection: $game) {
+                            ForEach(discoveredGames) { game in
+                                Text(game.title)
+                                    .tag(game)
+                            }
+                        }
+                        .disabled(discoveredGames.isEmpty)
+                        .withOperationStatus(
+                            operating: $isLoadingGames,
+                            successful: .constant(nil),
+                            observing: .constant(discoveredGames)
+                        ) { }
+
+                        HStack {
+                            VStack(alignment: .leading) {
+                                Label("Detected Install", systemImage: "shippingbox")
+                                Text(selectedGameLocationDescription)
+                                    .foregroundStyle(.secondary)
+                            }
+
+                            Spacer()
+                        }
+
+                        Label("Import registers an already-installed Windows Steam game; it does not copy files.",
+                              systemImage: "info")
+                        .symbolVariant(.circle)
+                        .foregroundStyle(.secondary)
+                        .font(.footnote)
+                    }
+                }
+                .formStyle(.grouped)
+            }
+
+            HStack {
+                Button("Cancel", role: .cancel) {
+                    isPresented = false
+                }
+
+                Spacer()
+
+                OperationButton(
+                    "Done",
+                    operating: $isImporting,
+                    successful: $importSuccessful,
+                    placement: .leading
+                ) {
+                    guard let steamRootURL else { return }
+
+                    do {
+                        try await SteamGameManager.importGame(game, in: steamRootURL, platform: .windows)
+                        importSuccessful = true
+                        isPresented = false
+                    } catch {
+                        importSuccessful = false
+                        importError = error
+                        isImportErrorAlertPresented = true
+                    }
+                }
+                .disabled(!isReadyToImport)
+                .buttonStyle(.borderedProminent)
+            }
+            .padding([.horizontal, .bottom])
+        }
+        .alert("Error importing Steam game.",
+               isPresented: $isImportErrorAlertPresented,
+               presenting: importError) { _ in
+            if #available(macOS 26.0, *) {
+                Button("OK", role: .close, action: {})
+            } else {
+                Button("OK", role: .cancel, action: {})
+            }
+        } message: { error in
+            Text(error.localizedDescription)
+        }
+        .task(id: refreshKey) {
+            await refreshDiscoveredGames()
+        }
+    }
+}
+
+#Preview {
+    SteamGameImportView(isPresented: .constant(true))
+}

--- a/Mythic/Views/Unified/Sheets/GameSettingsView.swift
+++ b/Mythic/Views/Unified/Sheets/GameSettingsView.swift
@@ -173,7 +173,7 @@ struct GameSettingsView: View {
                                     Button("Move...") {
                                         isMovingFileImporterPresented = true
                                     }
-                                    .disabled(operationManager.queue.first?.game == game)
+                                    .disabled(!game.supportsMoving || operationManager.queue.first?.game == game)
                                     // FIXME: xcode's code formatter does NOT like using stacked parameters,
                                     // FIXME: it messes up the indent for the .alert below this
                                     .fileImporter(

--- a/Mythic/Views/Unified/Windows/SettingsView.swift
+++ b/Mythic/Views/Unified/Windows/SettingsView.swift
@@ -321,15 +321,22 @@ extension SettingsView {
 
     struct ServicesView: View {
         @AppStorage("discordRPC") private var discordRPCEnabled: Bool = true
+        @AppStorage(Steam.rootPathUserDefaultsKey) private var steamRootPath: String = ""
+        
         @State private var isServicesDiscordSectionExpanded: Bool = true
         @State private var isServicesEpicSectionExpanded: Bool = true
-
+        @State private var isServicesSteamSectionExpanded: Bool = true
+        
         @State private var isCleaning: Bool = false
         @State private var isCleanupSuccessful: Bool?
-
+        
         @State private var isEpicCloudSynchronising: Bool = false
         @State private var isEpicCloudSyncSuccessful: Bool?
-
+        
+        @State private var isSteamRootImporterPresented: Bool = false
+        @State private var steamRefreshError: Error?
+        @State private var isSteamRefreshErrorPresented: Bool = false
+        
         var body: some View {
             Section("Discord", isExpanded: $isServicesDiscordSectionExpanded) {
                 Toggle("Display Mythic activity status on Discord", isOn: $discordRPCEnabled)
@@ -343,7 +350,7 @@ extension SettingsView {
             }
             .disabled(!discordRPC.isDiscordInstalled)
             .help(discordRPC.isDiscordInstalled ? .init() : "Discord is not installed.")
-
+            
             Section("Epic Games", isExpanded: $isServicesEpicSectionExpanded) {
                 OperationButton(
                     "Clean Up Miscellaneous Caches",
@@ -359,7 +366,7 @@ extension SettingsView {
                     let result = try? await process.runWrapped()
                     isCleanupSuccessful = result?.standardError?.contains("Cleanup complete")
                 }
-
+                
                 OperationButton(
                     "Manually Synchronise Cloud Saves",
                     systemImage: "arrow.trianglehead.2.clockwise.rotate.90",
@@ -376,12 +383,97 @@ extension SettingsView {
                     
                     isEpicCloudSyncSuccessful = (try? regex.firstMatch(in: result?.standardError ?? "") != nil)
                 }
-
+                
                 // TODO: potenially add manual cloud save deletion
             }
-
-            Section("Steam", isExpanded: .constant(false)) { }
-                .help("Coming Soon")
+            
+            Section("Steam", isExpanded: $isServicesSteamSectionExpanded) {
+                HStack {
+                    VStack(alignment: .leading) {
+                        Label("Steam Library Root", systemImage: "shippingbox")
+                        
+                        HStack {
+                            Text(steamRootURL?.prettyPath ?? "Steam not found")
+                                .foregroundStyle(.secondary)
+                            
+                            if steamRootURL == nil {
+                                Image(systemName: "exclamationmark.triangle")
+                                    .symbolVariant(.fill)
+                                    .help("Steam was not found in the default macOS location. Choose a Steam folder manually to continue.")
+                            } else if !isSteamMetadataAvailable {
+                                Image(systemName: "exclamationmark.triangle")
+                                    .symbolVariant(.fill)
+                                    .help("The selected Steam root does not contain steamapps/libraryfolders.vdf.")
+                            }
+                        }
+                        
+                        Text(Steam.isUsingCustomRootURL ? "Using custom location" : "Using default macOS location")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        
+                        Label(Steam.isClientInstalled ? "Steam client detected" : "Steam client not detected",
+                              systemImage: Steam.isClientInstalled ? "checkmark.circle.fill" : "xmark.circle.fill")
+                            .font(.caption)
+                            .foregroundStyle(Steam.isClientInstalled ? .green : .secondary)
+                        
+                        Text(isSteamMetadataAvailable
+                             ? "Installed Steam games can be refreshed from this library."
+                             : "Mythic needs steamapps/libraryfolders.vdf to discover installed Steam games.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    
+                    Spacer()
+                    
+                    VStack(alignment: .trailing) {
+                        Button("Browse...") {
+                            isSteamRootImporterPresented = true
+                        }
+                        .fileImporter(
+                            isPresented: $isSteamRootImporterPresented,
+                            allowedContentTypes: [.folder]
+                        ) { result in
+                            if case .success(let url) = result {
+                                steamRootPath = url.path
+                                refreshSteamLibrary()
+                            }
+                        }
+                        .buttonStyle(.borderedProminent)
+                        
+                        Button("Reset to Default") {
+                            steamRootPath = ""
+                            refreshSteamLibrary()
+                        }
+                        .disabled(!Steam.isUsingCustomRootURL)
+                    }
+                }
+            }
+            .help("Configure where Mythic looks for Steam libraries.")
+            .alert("Unable to refresh Steam library.",
+                   isPresented: $isSteamRefreshErrorPresented,
+                   presenting: steamRefreshError) { _ in
+                if #available(macOS 26.0, *) {
+                    Button(role: .close, action: {})
+                } else {
+                    Button("OK", role: .cancel, action: {})
+                }
+            } message: { error in
+                Text(error.localizedDescription)
+            }
+        }
+        
+        private var steamRootURL: URL? { Steam.rootURL }
+        private var isSteamMetadataAvailable: Bool { Steam.containsLibraryMetadata(in: steamRootURL) }
+        
+        private func refreshSteamLibrary() {
+            Task(priority: .userInitiated) { @MainActor in
+                do {
+                    try await GameDataStore.shared.refreshFromStorefronts(.steam)
+                } catch {
+                    steamRefreshError = error
+                    isSteamRefreshErrorPresented = true
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Introduce first-class Steam support: add a new Steam utility (VDF parser, library/manifest enumeration, artwork and launch URL helpers), SteamGame model, and SteamGameManager for import and launch flows (including Windows Steam installs inside Wine containers). Extend Game with per-operation capability flags and a UnsupportedOperationError type, relocate/implement Codable encoding and strengthen Equatable/Hashable to include concrete type. Integrate Steam refresh into GameDataStore (merge/upsert/reconcile installed Steam games and discover Steam library sources). Update EpicGamesGame and LocalGame to declare supported operations and return meaningful errors for unsupported actions. UI updates enable/disable actions based on game capability flags and adjust import tabs to include Steam. Replace background Sparkle scheduling with a main-run-loop Timer and add project file entries for the new sources. Many Steam-related operations are still unimplemented and currently surface UnsupportedOperationError placeholders.

TS AI SLOP IT AMLOST KIND OF WORKS