### PR TITLE
fix: simplified rosetta 2 installation status check

### DIFF
--- a/Mythic/Utilities/Rosetta.swift
+++ b/Mythic/Utilities/Rosetta.swift
@@ -10,14 +10,9 @@
 import Foundation
 
 final class Rosetta {
-    static var exists: Bool { // thread-blocking, but ~0.04 sec cpu time
-        let process: Process = .init()
-        process.executableURL = .init(filePath: "/usr/bin/pgrep")
-        process.arguments = ["oahd"]
-
-        let result = try? process.runWrapped()
-
-        return result?.standardOutput?.isEmpty == false
+    static var isInstalled: Bool {
+        FileManager.default.isExecutableFile(
+            atPath: "/Library/Apple/usr/libexec/oah/libRosettaRuntime")
     }
 
     struct AgreementFailure: LocalizedError {

--- a/Mythic/Views/Unified/Sheets/RosettaInstallationView.swift
+++ b/Mythic/Views/Unified/Sheets/RosettaInstallationView.swift
@@ -94,7 +94,7 @@ extension RosettaInstallationView {
             ProgressView(value: percentageCompletion, total: 100.0)
                 .progressViewStyle(.linear)
                 .task {
-                    guard !Rosetta.exists else {
+                    guard !Rosetta.isInstalled else {
                         viewModel.stepStage(); return
                     }
 


### PR DESCRIPTION
replaced the old process-based Rosetta 2 installation status check with a faster file-based one which check for `/Library/Apple/usr/libexec/oah/libRosettaRuntime` executable instead. 