### PR TITLE
fix: resolve multiple reported game and web bugs

### DIFF
--- a/Mythic/Utilities/Game/EpicGamesGame.swift
+++ b/Mythic/Utilities/Game/EpicGamesGame.swift
@@ -10,7 +10,7 @@
 import Foundation
 import AppKit
 
-class EpicGamesGame: Game {
+class EpicGamesGame: Game, @unchecked Sendable {
     override var storefront: Storefront? { .epicGames }
 
     override var computedVerticalImageURL: URL? { Legendary.getImageURL(gameID: self.id, type: .tall) }

--- a/Mythic/Utilities/GameManager/EpicGamesGameManager.swift
+++ b/Mythic/Utilities/GameManager/EpicGamesGameManager.swift
@@ -58,7 +58,7 @@ extension EpicGamesGameManager: StorefrontGameManager {
         guard case .epicGames = game.storefront,
               let castGame = game as? EpicGamesGame else { throw CocoaError(.coderInvalidValue) }
 
-        return try await Task(operation: { try await launch(game: castGame) }).value
+        return try await launch(game: castGame)
     }
 
     @MainActor static func move(game: Game,
@@ -66,7 +66,7 @@ extension EpicGamesGameManager: StorefrontGameManager {
         guard case .epicGames = game.storefront,
               let castGame = game as? EpicGamesGame else { throw CocoaError(.coderInvalidValue) }
 
-        return try await Task(operation: { try await move(game: castGame, to: location) }).value
+        return try await move(game: castGame, to: location)
     }
 
     @MainActor static func uninstall(game: Game,

--- a/Mythic/Utilities/GameManager/Legendary/LegendaryInterface.swift
+++ b/Mythic/Utilities/GameManager/Legendary/LegendaryInterface.swift
@@ -56,6 +56,10 @@ final class Legendary {
     }
     
     static func handleCLIErrorOutput(fromStandardErrorOutput output: String) throws {
+        if output.contains("ValueError: No saved credentials") {
+            throw NotSignedInError()
+        }
+
         for line in output.split(whereSeparator: \.isNewline) {
             if let match = try? Regex(#"(ERROR|CRITICAL): (.*)"#).firstMatch(in: line),
                let errorReason = match.last?.substring {
@@ -103,7 +107,7 @@ final class Legendary {
                                                             progress: Progress) {
         // these regexes are not dynamic, so there's no reason why they should fail to initialise
         // swiftlint:disable force_try
-        let progressRegex: Regex = try! .init(#"Progress: (?<percentage>\d+\.\d+)% \((?<downloadedObjects>\d+)\/(?<totalObjects>\d+)\), Running for (?<runtime>\d+:\d+:\d+), ETA: (?<eta>\d+:\d+:\d+)"#)
+        let progressRegex: Regex = try! .init(#"Progress: (?<percentage>\d+(?:\.\d+)?)% \((?<downloadedObjects>\d+)\/(?<totalObjects>\d+)\), Running for (?<runtime>\d+:\d+:\d+), ETA: (?<eta>(?:\d+:\d+:\d+|--:--:--|Unknown))"#)
         // let downloadRegex: Regex = try! .init(#"Downloaded: (?<downloaded>\d+\.\d+) \w+, Written: (?<written>\d+\.\d+) \w+"#)
         // let cacheRegex: Regex = try! .init(#"Cache usage: (?<usage>\d+\.\d+) \w+, active tasks: (?<activeTasks>\d+)"#)
         let downloadSpeedRegex: Regex = try! .init(#"\+ Download\s+- (?<raw>[\d.]+) \w+/\w+ \(raw\) / (?<decompressed>[\d.]+) \w+/\w+ \(decompressed\)"#)
@@ -410,8 +414,10 @@ final class Legendary {
             throw CocoaError(.fileNoSuchFile)
         }
 
+        let destinationURL = newLocation.appending(path: currentLocation.lastPathComponent)
+
         let operation: GameOperation = .init(game: game, type: .move) { _ in
-            try FileManager.default.moveItem(at: currentLocation, to: newLocation)
+            try FileManager.default.moveItem(at: currentLocation, to: destinationURL)
 
             let process: Process = .init()
             process.arguments = ["move", game.id, newLocation.path, "--skip-move"]
@@ -424,7 +430,7 @@ final class Legendary {
             
             try handleCLIErrorOutput(fromStandardErrorPipe: processStandardErrorPipe)
             
-            game.installationState = .installed(location: newLocation, platform: platform)
+            game.installationState = .installed(location: destinationURL, platform: platform)
         }
 
         await Game.operationManager.queueOperation(operation)

--- a/Mythic/Utilities/GameManager/LocalGameManager.swift
+++ b/Mythic/Utilities/GameManager/LocalGameManager.swift
@@ -91,6 +91,7 @@ class LocalGameManager {
                 
                 let process: Process = .init()
                 process.arguments = [location.path] + game.launchArguments
+                process.currentDirectoryURL = location.deletingLastPathComponent()
                 process.environment = environment
                 Wine.transformProcess(process, containerURL: containerURL)
                 
@@ -111,10 +112,13 @@ class LocalGameManager {
             throw CocoaError(.fileNoSuchFile)
         }
 
-        let operation: GameOperation = .init(game: game, type: .uninstall) {  _ in
-            try FileManager.default.moveItem(at: currentLocation, to: newLocation)
-            game.installationState = .installed(location: newLocation, platform: platform)
+        let destinationURL = newLocation.appending(path: currentLocation.lastPathComponent)
+
+        let operation: GameOperation = .init(game: game, type: .move) {  _ in
+            try FileManager.default.moveItem(at: currentLocation, to: destinationURL)
+            game.installationState = .installed(location: destinationURL, platform: platform)
         }
+        Game.operationManager.queueOperation(operation)
         return operation
     }
 

--- a/Mythic/Views/Navigation/SupportView.swift
+++ b/Mythic/Views/Navigation/SupportView.swift
@@ -33,7 +33,7 @@ struct SupportView: View {
                 }
                 verticalDivider(height: 30)
                 Button("FAQ"){
-                    openLink(urlString: "https://getmythic.app/faq/")
+                    openLink(urlString: "https://docs.getmythic.app/docs/faq/")
                 }
                 verticalDivider(height: 30)
                 Button("Compatibility List"){

--- a/Mythic/Views/Unified/Components/WebView.swift
+++ b/Mythic/Views/Unified/Components/WebView.swift
@@ -27,11 +27,12 @@ struct WebView: NSViewRepresentable {
         
         let webView = WKWebView(frame: .zero, configuration: config)
         webView.navigationDelegate = context.coordinator
+        webView.load(URLRequest(url: url))
         return webView
     }
     
     func updateNSView(_ nsView: WKWebView, context: Context) {
-        if nsView.url != self.url {
+        if nsView.url == nil || url.scheme == "javascript" {
             let request = URLRequest(url: self.url)
             nsView.load(request)
         }

--- a/Mythic/Views/Unified/Windows/EpicWebAuthView.swift
+++ b/Mythic/Views/Unified/Windows/EpicWebAuthView.swift
@@ -161,11 +161,22 @@ private struct EpicInterceptorWebView: NSViewRepresentable {
 
     let completion: (String) -> Void
 
-    class Coordinator: NSObject, WKNavigationDelegate {
+    class Coordinator: NSObject, WKNavigationDelegate, WKUIDelegate {
         let parent: EpicInterceptorWebView
 
         init(parent: EpicInterceptorWebView) {
             self.parent = parent
+        }
+
+        func webView(_ webView: WKWebView,
+                     createWebViewWith configuration: WKWebViewConfiguration,
+                     for navigationAction: WKNavigationAction,
+                     windowFeatures: WKWindowFeatures) -> WKWebView? {
+            if navigationAction.targetFrame == nil {
+                webView.load(navigationAction.request)
+            }
+
+            return nil
         }
 
         func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
@@ -237,6 +248,7 @@ private struct EpicInterceptorWebView: NSViewRepresentable {
 
         let webView = WKWebView(frame: .zero, configuration: config)
         webView.navigationDelegate = context.coordinator
+        webView.uiDelegate = context.coordinator
         webView.load(URLRequest(url: URL(string: "https://legendary.gl/epiclogin")!))
         return webView
     }


### PR DESCRIPTION
## Summary
- Fix FAQ support link to point at the docs FAQ instead of the removed website route.
- Keep Epic third-party login links in the embedded auth web view instead of dropping target=_blank navigations.
- Stop the Store WebView from reloading back to the store home URL on SwiftUI updates/window focus changes.
- Surface Legendary “No saved credentials” failures as the existing Epic not-signed-in error.
- Make download progress parsing tolerate integer percentages and non-time ETA values.
- Fix local and Epic move operations to move into the selected folder, track them as move operations, and queue local moves.
- Launch local Windows games from their executable directory so nearby config/INI files resolve correctly.

## Fixed issues
Fixes #266
Fixes #259
Fixes #218
Fixes #253
Fixes #217
Fixes #235
Fixes #237

## Test plan
- `xcodebuild -project Mythic.xcodeproj -scheme Mythic -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build`\n\nNote: Installed the missing Xcode Metal toolchain with `xcodebuild -downloadComponent MetalToolchain` after the first build attempt failed before compiling app code.