### PR TITLE
fix(`GameManager`): repair protocol dispatch for install and move (refs #289)

### DIFF
--- a/Mythic/Utilities/GameManager/EpicGamesGameManager.swift
+++ b/Mythic/Utilities/GameManager/EpicGamesGameManager.swift
@@ -23,7 +23,20 @@ extension EpicGamesGameManager: StorefrontGameManager {
         guard case .epicGames = game.storefront,
               let castGame = game as? EpicGamesGame else { throw CocoaError(.coderInvalidValue) }
 
-        return try await install(game: castGame, qualityOfService: qualityOfService)
+        // The typed overload requires `forPlatform:` and offers no default for it, so
+        // `install(game: castGame, qualityOfService:)` re-selects *this* witness (EpicGamesGame is a
+        // Game) and recurses until the stack dies. Resolve a platform explicitly instead.
+        // Windows wins when both are offered: it is the superset in practice, and Mythic runs it
+        // through Wine either way.
+        let supportedPlatforms = castGame.getSupportedPlatforms() ?? .init()
+        let resolvedPlatform: Game.Platform? = supportedPlatforms.contains(.windows)
+            ? .windows
+            : supportedPlatforms.first
+        guard let resolvedPlatform else { throw CocoaError(.coderInvalidValue) }
+
+        return try await install(game: castGame,
+                                 forPlatform: resolvedPlatform,
+                                 qualityOfService: qualityOfService)
     }
 
     static func update(game: Game, qualityOfService: QualityOfService) async throws -> GameOperation {

--- a/Mythic/Utilities/GameManager/LocalGameManager.swift
+++ b/Mythic/Utilities/GameManager/LocalGameManager.swift
@@ -111,10 +111,12 @@ class LocalGameManager {
             throw CocoaError(.fileNoSuchFile)
         }
 
-        let operation: GameOperation = .init(game: game, type: .uninstall) {  _ in
+        let operation: GameOperation = .init(game: game, type: .move) {  _ in
             try FileManager.default.moveItem(at: currentLocation, to: newLocation)
             game.installationState = .installed(location: newLocation, platform: platform)
         }
+
+        Game.operationManager.queueOperation(operation)
         return operation
     }
 


### PR DESCRIPTION
Two pre-existing defects in `StorefrontGameManager` witnesses, found while writing a new manager against them.

`EpicGamesGameManager.install(game:qualityOfService:)` recursed until the stack died. The typed overload requires `forPlatform:` and offers no default, so the call inside the witness re-selected the witness itself (`EpicGamesGame` *is* a `Game`). `StorefrontGameManager.install` is therefore unusable for Epic today — the UI only works because `EpicGamesGameInstallationView` calls the five-argument overload directly. The witness now resolves a platform from `getSupportedPlatforms()`, preferring Windows.

`LocalGameManager.move(game:to:)` built its operation with type `.uninstall` and never called `queueOperation`, so the returned operation was inert: its `function` never ran and moving a local game silently did nothing.

No behaviour changes for anything that already worked.