### PR TITLE
fix(`SparkleUpdateController`): stop the background task tripping an executor check (refs #289)

### DIFF
--- a/Mythic/Utilities/SparkleUpdateController.swift
+++ b/Mythic/Utilities/SparkleUpdateController.swift
@@ -52,7 +52,12 @@ final class SparkleUpdateController: NSObject, SPUUserDriver, ObservableObject {
                 backgroundQueue.schedule(
                     after: .init(.now()),
                     interval: .seconds(60 * 60 * 6)
-                ) {
+                ) { @Sendable in
+                    // @Sendable is load-bearing: without it this non-Sendable closure inherits the
+                    // enclosing MainActor isolation, so Swift 6 emits an executor check at its entry.
+                    // It then runs on `backgroundQueue`, dispatch_assert_queue fails, and the app traps
+                    // on launch (EXC_BREAKPOINT on the BackgroudEventService queue). The hop to the main
+                    // actor is the Task below, which is where it belongs.
                     Task { @MainActor in
                         SparkleUpdateController.shared.checkForUpdates(userInitiated: false)
                     }


### PR DESCRIPTION
The closure handed to `backgroundQueue.schedule` is non-Sendable, so under Swift 6 it inherits the enclosing `MainActor` isolation and the compiler emits an executor check at its entry. It then runs on `backgroundQueue`, where that check fails.

On Xcode 26.6 the app traps roughly two seconds after launch:

```
_dispatch_assert_queue_fail
swift_task_isCurrentExecutorWithFlagsImpl
closure #1 in SparkleUpdateController.manageBackgroundTask(_:)
```

Marking it `@Sendable` makes it properly non-isolated. The hop to the main actor is the `Task` inside it, which is where the hop belongs — so this is a correctness fix regardless of whether a given toolchain turns that check into a trap or a warning.

The usual workaround, `SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=legacy`, downgrades every executor assertion in the process to a warning, which hides real isolation bugs while testing.