### PR TITLE
fix(`AnyGame`): one unknown storefront tag no longer empties the library (refs #289)

### DIFF
--- a/Mythic/Utilities/Game/Game.swift
+++ b/Mythic/Utilities/Game/Game.swift
@@ -19,7 +19,10 @@ import AppKit
     var installationState: InstallationState
 
     var storefront: Storefront? {
-        assertionFailure("Storefront must always be populated by subclasses, when accessed.")
+        // Not an assertion: `AnyGame` deliberately degrades an unrecognised storefront tag to a bare
+        // `Game` rather than failing the whole library decode, so instances of this class do
+        // legitimately reach here.
+        Logger.app.warning("Storefront read on a base Game (\(self.id, privacy: .public)); it has no storefront.")
         return nil
     }
 
@@ -268,7 +271,11 @@ struct AnyGame: Codable, Equatable {
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: Game.CodingKeys.self)
-        let storefront = try container.decodeIfPresent(Game.Storefront.self, forKey: .storefront)
+        // `try?`, not `try`: a storefront tag this build does not recognise must degrade to a plain
+        // `Game`, never fail. `decodeAndGet` decodes the whole `[AnyGame]` array in one call and
+        // swallows any error into `nil`, so one unreadable row empties the entire library -- every
+        // game from every other storefront with it.
+        let storefront = try? container.decodeIfPresent(Game.Storefront.self, forKey: .storefront)
 
         self.base = try {
             switch storefront {


### PR DESCRIPTION
`AnyGame.init(from:)` decoded the storefront tag with `try`, so a tag the running build does not recognise throws. `GameDataStore` decodes the whole `[AnyGame]` array in one call and `UserDefaults.decodeAndGet` swallows any error into `nil`, which the observer reads as an empty library — so **a single unreadable row discards every game from every other storefront too**.

Measured on 0.6.0 by seeding `games` with one unknown storefront tag plus one ordinary local game:

| build | games surviving |
|---|---|
| 0.6.0 | **0 of 2** — library wiped, local game included |
| this change | **2 of 2** — unknown tag degraded, local untouched |

Worth shipping ahead of any new storefront case, because the build that needs the tolerance is the *older* one: by the time a new tag exists on disk, the release that cannot read it is already out.

`Game.storefront` on the base class logs instead of asserting, since a bare `Game` is now a legitimate decode outcome rather than a programmer error.